### PR TITLE
Fix thundernest links

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,7 +11,7 @@
   * [Managing Thunderbird Updates](manage-updates-policies-and-customization/managing-thunderbird-updates.md)
   * [Managing Thunderbird policies](manage-updates-policies-and-customization/managing-thunderbird-policies/README.md)
     * [Customizing Thunderbird using policies.json](manage-updates-policies-and-customization/managing-thunderbird-policies/customizing-thunderbird-using-policies.json.md)
-  * [Group Policy Templates](https://github.com/thundernest/policy-templates)
+  * [Group Policy Templates](https://github.com/thunderbird/policy-templates)
   * [Thunderbird Preferences Relevant to Enterprises](manage-updates-policies-and-customization/thunderbird-preferences-enterprise/README.md)
     * [Customize Thunderbird's date and time formats](manage-updates-policies-and-customization/thunderbird-preferences-enterprise/customize-thunderbirds-date-and-time-formats.md)
   * [Thunderbird Enterprise Tips](manage-updates-policies-and-customization/thunderbird-enterprise-tips.md)

--- a/explore/best-practices-for-installing-and-updating-thunderbird.md
+++ b/explore/best-practices-for-installing-and-updating-thunderbird.md
@@ -6,7 +6,7 @@ By default, automatic updates are enabled in Thunderbird. We recommend you keep 
   
 You can ensure that automatic updates are installed without user interference by using the [AppAutoUpdate](https://github.com/mozilla/policy-templates#appautoupdate) policy.
 
-If you need to turn off automatic updates, you can do this using the [DisableAppUpdate](https://github.com/thundernest/policy-templates/blob/master/README.md#disableappupdate) policy.
+If you need to turn off automatic updates, you can do this using the [DisableAppUpdate](https://github.com/thunderbird/policy-templates/blob/master/README.md#disableappupdate) policy.
 
 For more information on policies, see [Managing Thunderbird policies](../manage-updates-policies-and-customization/managing-thunderbird-policies/).
 

--- a/manage-updates-policies-and-customization/managing-thunderbird-policies/customizing-thunderbird-using-policies.json.md
+++ b/manage-updates-policies-and-customization/managing-thunderbird-policies/customizing-thunderbird-using-policies.json.md
@@ -22,7 +22,7 @@ The policies.json file looks like this:
 
 In this example, we are setting the `BlockAboutConfig` policy to `true`, which means that the user will not have access to the `about:config` page.
 
-The latest information about our policies is available in [the README on our GitHub repository](https://github.com/thundernest/policy-templates/blob/master/README.md).
+The latest information about our policies is available in [the README on our GitHub repository](https://github.com/thunderbird/policy-templates/blob/master/README.md).
 
 {% hint style="warning" %}
 **NOTE:** The above method will not work if Thunderbird is already being managed using Windows Group Policy.

--- a/manage-updates-policies-and-customization/managing-thunderbird-updates.md
+++ b/manage-updates-policies-and-customization/managing-thunderbird-updates.md
@@ -20,5 +20,5 @@ Thunderbird's release and beta version numbers generally match those of Mozilla 
 
 ## Disabling Thunderbird updates
 
-Automatic updates are enabled by default, but you can disable them using the [DisableAppUpdate policy](https://github.com/thundernest/policy-templates/blob/master/README.md#disableappupdate).
+Automatic updates are enabled by default, but you can disable them using the [DisableAppUpdate policy](https://github.com/thunderbird/policy-templates/blob/master/README.md#disableappupdate).
 


### PR DESCRIPTION
Fix links which are still using the old org name "thundernest" instead of "thunderbird".